### PR TITLE
use display mesh instead of imported mesh

### DIFF
--- a/MesherCommand.py
+++ b/MesherCommand.py
@@ -8,7 +8,7 @@ from .Fusion360Utilities.Fusion360CommandBase import Fusion360CommandBase
 
 def mesh_brep_interference(mesh_body: adsk.fusion.MeshBody, brep_bodies: adsk.fusion.BRepBodies):
 
-    nodes = mesh_body.mesh.nodeCoordinates
+    nodes = mesh_body.displayMesh.nodeCoordinates
 
     contained_nodes = []
     boundary_nodes = []


### PR DESCRIPTION
The 'mesh' attribute is always the imported nodes, they are not transformed by rotations and translation.
A quick and dirty way to overcome that is to use the displayMesh attribute instead.